### PR TITLE
Clear button in TextinputField and camelCase tokens fix

### DIFF
--- a/cypress/e2e/sandbox_spec.js
+++ b/cypress/e2e/sandbox_spec.js
@@ -4,18 +4,39 @@ import { TOKENS, CSS_TOKENS } from '../constants'
 describe('Sandbox', () => {
   beforeEach(() => cy.visit('/'))
 
-  it('should show valid yaml and css', () => {
-
+  it('should show valid yaml and css when upload theme', () => {
+		// Upload the theme 
     cy.findByText('Загрузить тему').click()
-
     cy.findByTestId('tokens-textarea').clear().type(TOKENS)
-
     cy.findByTestId('tokens-upload-button').click({ force: true })
 
+		// Validate generated yaml and css
     cy.findByText('YAML').click()
     cy.get('code').should('have.text', TOKENS)
 
     cy.findByText('CSS').click()
     cy.get('code').should('have.text', CSS_TOKENS)
   })
+
+	it('should correctly generate yaml and css using textinput', () => {
+		// `targetYaml` and `targetCss` are taken from test execution
+		const targetYaml = `button:\n  border:\n    radius:\n      value: 10px\n  viewAction:\n    fillColor:\n      base:\n        value: "#ff0"\n      disabled:\n        value: color({button.viewAction.borderColor.focused.value} a(10%))\n    borderColor:\n      focused:\n        value: "#fc0"\n`
+		const targetCss = `:root {\n  --button-borderRadius: 10px;\n  --button-view-action-fill-color-base: #ff0;\n  --button-view-action-fill-color-disabled: rgba(255, 204, 0, 0.1);\n  --button-view-action-border-color-focused: #fc0;\n}`
+
+		// Go to tab with button tokens
+		cy.findByTestId('tokens-select').click()
+		cy.findByText('button').click()
+
+		// Set new values in token textinputs
+		cy.findByTestId('button-borderRadius').clear().type('10px')
+		cy.findByTestId('button-view-action-fill-color-base').clear().type('#ff0')
+		cy.findByTestId('button-view-action-fill-color-disabled').clear().type('color({button-view-action-border-color-focused} a(10%))', { parseSpecialCharSequences: false })
+
+		// Validate generated yaml and css
+    cy.findByText('YAML').click()
+    cy.get('code').should('have.text', targetYaml)
+
+    cy.findByText('CSS').click()
+    cy.get('code').should('have.text', targetCss)
+	})
 })

--- a/src/components/Sandbox/Sandbox.tsx
+++ b/src/components/Sandbox/Sandbox.tsx
@@ -3,6 +3,7 @@ import { Select } from '@yandex/ui/Select/Select.bundle/desktop'
 import { Textinput } from '@yandex/ui/Textinput/Textinput.bundle/desktop'
 import { TabsMenu } from '@yandex/ui/TabsMenu/TabsMenu.bundle/desktop'
 import { TabsPanes } from '@yandex/ui/TabsPanes/TabsPanes.bundle/desktop'
+import { Button } from '@yandex/ui/Button/desktop/bundle'
 import { useStore } from 'effector-react'
 
 import { TextinputField } from '../TextinputField'
@@ -51,6 +52,11 @@ export const Sandbox: React.FC<SandboxProps> = (props) => {
             setActiveTab(event.target.value)
             metricaGoal('select')
           }}
+          renderTrigger={({ children, ...props }) => (
+            <Button {...props} data-testid="tokens-select">
+              {children}
+            </Button>
+          )}
           value={activeTab}
           options={tabs.map((tab) => ({ value: tab, content: tab }))}
         />

--- a/src/components/TextinputField/TextinputField.tsx
+++ b/src/components/TextinputField/TextinputField.tsx
@@ -109,6 +109,7 @@ export const TextinputField: React.FC<{
           value={val}
           hint={isChanged ? `Оригинальное значение - ${defaultValue}` : ''}
           className="TextinputField-Input"
+          data-testid={label}
         />
         {isColorValue && <ColorPicker color={colorValue} onColorChange={handleColorChange} />}
       </div>

--- a/src/model/resolvedTokens.ts
+++ b/src/model/resolvedTokens.ts
@@ -11,11 +11,9 @@ export const $resolvedTokens = createStore<DesignTokensType>({})
 const resolvedTokensUpdate = createEvent<VariablesType[]>()
 
 $resolvedTokens
-  .on(resolvedTokensUpdate, (state, tokens) => {
-    const ret: Record<string, any> = {}
-    tokens.forEach((v) => (ret[v.name] = v))
-    return { ...state, ...ret }
-  })
+  .on(resolvedTokensUpdate, (_, tokens) =>
+    tokens.reduce((acc, token) => ({ ...acc, [token.name]: token }), {}),
+  )
   .reset(variablesReset)
 
 export const resolveTokensFx = createEffect(

--- a/src/model/resolvedTokens.ts
+++ b/src/model/resolvedTokens.ts
@@ -4,7 +4,7 @@ import { downloadTheme } from '../api/downloadTheme'
 import { variablesReset } from './designTokens'
 import { $yamlText } from './yaml'
 import { DesignTokensType, VariablesType, MappingsType } from '../types'
-import { $invertedTokenMappings } from './mappings'
+import { $theme } from './themes'
 
 export const $resolvedTokens = createStore<DesignTokensType>({})
 
@@ -24,8 +24,8 @@ export const resolveTokensFx = createEffect(
 
 export const resolveTokensAttach = attach({
   effect: resolveTokensFx,
-  source: $invertedTokenMappings,
-  mapParams: (content: string, mappings: MappingsType) => ({
+  source: $theme,
+  mapParams: (content: string, { mappings }) => ({
     content,
     mappings,
   }),


### PR DESCRIPTION
1. Теперь при каждом изменении токена перебилдиваются все токены, соответственно предыдущий стейт не нужен. Это приводило к ошибке при сбросе переменной, так как предыдущее значение оставалось в стейте.
2. Передавались не правильные токены в themekit, из-за чего css переменные в camelCase стиле превращались в snake-case, что приводило к неправильному поведению программы